### PR TITLE
Extended order_by auto scope and fixed filter-menu to correctly work with options elements array

### DIFF
--- a/hobo/lib/hobo/lifecycles/transition.rb
+++ b/hobo/lib/hobo/lifecycles/transition.rb
@@ -34,8 +34,8 @@ module Hobo
 
 
       def change_state(record)
-        record.lifecycle.become(get_state(record, end_state))
         record.lifecycle.clear_key unless options[:new_key] || options[:keep_key]
+        return record.lifecycle.become(get_state(record, end_state))
       end
 
 

--- a/hobo/lib/hobo/model_controller.rb
+++ b/hobo/lib/hobo/model_controller.rb
@@ -455,6 +455,7 @@ module Hobo
 
       if do_pagination
         options.reverse_merge!(:page => params[:page] || 1)
+        options[:order] = :created_at if options[:order] == :default
         finder.paginate(options)
       else
         finder.all(options.except(*WILL_PAGINATE_OPTIONS))

--- a/hobo/lib/hobo/scopes/named_scope_extensions.rb
+++ b/hobo/lib/hobo/scopes/named_scope_extensions.rb
@@ -13,7 +13,7 @@ module ActiveRecord
       private
       
       def method_missing(method, *args, &block)
-        if scopes.include?(method)
+        if respond_to?(method) && scopes.include?(method)
           scopes[method].call(self, *args)
         else
           with_scope :find => proxy_options do

--- a/hobo/rapid_generators/rapid/pages.dryml.erb
+++ b/hobo/rapid_generators/rapid/pages.dryml.erb
@@ -140,7 +140,7 @@ end
             <a:<%= back_link %> param="parent-link">&laquo; <ht key="<%= model_key %>.actions.back" to="<%= back_link %>"><name/></ht></a:<%= back_link %>>
 <% end -%>
             <h2 param="heading">
-              <ht key="<%= model_key %>.show.heading" name="&this.respond_to?(:name) ? this.name : ''">
+              <ht key="<%= model_key %>.show.heading" name="&this.respond_to?(:name) ? this.name : this.send(this.class.name_attribute)">
                 <name/>
               </ht>
             </h2>

--- a/hobo/rapid_generators/rapid/pages.dryml.erb
+++ b/hobo/rapid_generators/rapid/pages.dryml.erb
@@ -175,7 +175,7 @@ end
 <% if collection -%>
             <section param="collection-section">
               <h3 param="collection-heading">
-                <ht key="<%= model_key %>.collection.heading.<%= (is_user_model ? 'your':'other') %>" >
+                <ht key="<%= collection.to_s.tableize %>.collection.heading.<%= (is_user_model ? 'your':'other') %>" >
                   <%= '<Your/>' if is_user_model %><%= collection.to_s.titleize %>
                 </ht>
               </h3>

--- a/hobo/rapid_generators/rapid/pages.dryml.erb
+++ b/hobo/rapid_generators/rapid/pages.dryml.erb
@@ -140,7 +140,7 @@ end
             <a:<%= back_link %> param="parent-link">&laquo; <ht key="<%= model_key %>.actions.back" to="<%= back_link %>"><name/></ht></a:<%= back_link %>>
 <% end -%>
             <h2 param="heading">
-              <ht key="<%= model_key %>.show.heading" name="&this.respond_to?(:name) ? this.name : this.send(this.class.name_attribute)">
+              <ht key="<%= model_key %>.show.heading" name="&this.respond_to?(:to_s) ? this.to_s : ''">
                 <name/>
               </ht>
             </h2>

--- a/hobo/taglibs/rapid_core.dryml
+++ b/hobo/taglibs/rapid_core.dryml
@@ -468,13 +468,13 @@ Assuming the context is a blog post...
 <def tag="links-for-collection"><%= this.empty? ? "(none)" : context_map { a }.join(", ") %></def>
 
 <!-- Renders `this.to_s(:long)`, or `this.strftime(format)` if the `format` attribute is given -->
-<def tag="view" for="Date" attrs="format"><%= this && (format ? l(this, :format => format) : l(this, :format => :long)) %></def>
+<def tag="view" for="Date" attrs="format"><%= this && (format ? I18n.l(this, :format => format) : I18n.l(this, :format => :long)) %></def>
 
 <!-- Renders `this.to_s(:long)`, or `this.strftime(format)` if the `format` attribute is given -->
-<def tag="view" for="Time" attrs="format"><%= this && (format ? l(this, :format => format) : l(this, :format => :long)) %></def>
+<def tag="view" for="Time" attrs="format"><%= this && (format ? I18n.l(this, :format => format) : I18n.l(this, :format => :long)) %></def>
 
 <!-- Renders `this.to_s(:long)`, or `this.strftime(format)` if the `format` attribute is given -->
-<def tag="view" for="ActiveSupport::TimeWithZone" attrs="format"><%= this && (format ? l(this, :format => format) : l(this, :format => :long)) %></def>
+<def tag="view" for="ActiveSupport::TimeWithZone" attrs="format"><%= this && (format ? I18n.l(this, :format => format) : I18n.l(this, :format => :long)) %></def>
 
 <!-- Renders `this.to_s`, or `format % this` if the `format` attribute is given -->
 <def tag="view" for="Numeric" attrs="format"><%= format ? format % this : this.to_s %></def>

--- a/hobo/taglibs/rapid_core.dryml
+++ b/hobo/taglibs/rapid_core.dryml
@@ -467,13 +467,13 @@ Assuming the context is a blog post...
 <!-- Renders a comma separated list of links (`<a>`), or "(none)" if the list is empty -->
 <def tag="links-for-collection"><%= this.empty? ? "(none)" : context_map { a }.join(", ") %></def>
 
-<!-- Renders `this.to_s(:long)`, or `this.strftime(format)` if the `format` attribute is given -->
+<!-- Renders `I18n.l(this, :format => :long)`, or `I18n.l(this, :format => format)` if the `format` attribute is given -->
 <def tag="view" for="Date" attrs="format"><%= this && (format ? I18n.l(this, :format => format) : I18n.l(this, :format => :long)) %></def>
 
-<!-- Renders `this.to_s(:long)`, or `this.strftime(format)` if the `format` attribute is given -->
+<!-- Renders `I18n.l(this, :format => :long)`, or `I18n.l(this, :format => format)` if the `format` attribute is given -->
 <def tag="view" for="Time" attrs="format"><%= this && (format ? I18n.l(this, :format => format) : I18n.l(this, :format => :long)) %></def>
 
-<!-- Renders `this.to_s(:long)`, or `this.strftime(format)` if the `format` attribute is given -->
+<!-- Renders `I18n.l(this, :format => :long)`, or `I18n.l(this, :format => format)` if the `format` attribute is given -->
 <def tag="view" for="ActiveSupport::TimeWithZone" attrs="format"><%= this && (format ? I18n.l(this, :format => format) : I18n.l(this, :format => :long)) %></def>
 
 <!-- Renders `this.to_s`, or `format % this` if the `format` attribute is given -->
@@ -488,11 +488,14 @@ Assuming the context is a blog post...
   end
 %></def>
 
-<!-- Renders 'Yes' for true and 'No' for false -->
+<!-- Renders 'Yes' for true and 'No' for false with localization support -->
 <def tag="view" for="boolean"><%= this ? ht('hobo.boolean_yes', {:default => 'Yes'}) : ht('hobo.boolean_no', {:default => 'No'}) %></def>
 
 <!-- Renders a link (`<a>`) to `this` -->
 <def tag="view" for="ActiveRecord::Base"><a merge-attrs/></def>
+
+<!-- Renders `this.to_s` with localization support -->
+<def tag="view" for="HoboFields::LifecycleState"><ht key='#{this.class.parent.name.tableize}.lifecycle_states.#{this.to_s.downcase}'><%= this.to_s %></ht></def>
 
 
 <!--

--- a/hobo/taglibs/rapid_core.dryml
+++ b/hobo/taglibs/rapid_core.dryml
@@ -489,7 +489,7 @@ Assuming the context is a blog post...
 %></def>
 
 <!-- Renders 'Yes' for true and 'No' for false -->
-<def tag="view" for="boolean"><%= this ? 'Yes' : 'No' %></def>
+<def tag="view" for="boolean"><%= this ? I18n.t('hobo.boolean_yes', :default => 'Yes') : I18n.t('hobo.boolean_no', :default => 'no') %></def>
 
 <!-- Renders a link (`<a>`) to `this` -->
 <def tag="view" for="ActiveRecord::Base"><a merge-attrs/></def>

--- a/hobo/taglibs/rapid_core.dryml
+++ b/hobo/taglibs/rapid_core.dryml
@@ -468,13 +468,13 @@ Assuming the context is a blog post...
 <def tag="links-for-collection"><%= this.empty? ? "(none)" : context_map { a }.join(", ") %></def>
 
 <!-- Renders `this.to_s(:long)`, or `this.strftime(format)` if the `format` attribute is given -->
-<def tag="view" for="Date" attrs="format"><%= this && (format ? this.strftime(format) : this.to_s(:long)) %></def>
+<def tag="view" for="Date" attrs="format"><%= this && (format ? l(this, :format => format) : l(this, :format => :long)) %></def>
 
 <!-- Renders `this.to_s(:long)`, or `this.strftime(format)` if the `format` attribute is given -->
-<def tag="view" for="Time" attrs="format"><%= this && (format ? this.strftime(format) : this.to_s(:long)) %></def>
+<def tag="view" for="Time" attrs="format"><%= this && (format ? l(this, :format => format) : l(this, :format => :long)) %></def>
 
 <!-- Renders `this.to_s(:long)`, or `this.strftime(format)` if the `format` attribute is given -->
-<def tag="view" for="ActiveSupport::TimeWithZone" attrs="format"><%= this && (format ? this.strftime(format) : this.to_s(:long)) %></def>
+<def tag="view" for="ActiveSupport::TimeWithZone" attrs="format"><%= this && (format ? l(this, :format => format) : l(this, :format => :long)) %></def>
 
 <!-- Renders `this.to_s`, or `format % this` if the `format` attribute is given -->
 <def tag="view" for="Numeric" attrs="format"><%= format ? format % this : this.to_s %></def>

--- a/hobo/taglibs/rapid_core.dryml
+++ b/hobo/taglibs/rapid_core.dryml
@@ -496,7 +496,7 @@ Assuming the context is a blog post...
 
 <!-- Renders `this.to_s` with localization support -->
 <def tag="view" for="HoboFields::LifecycleState">
-    <span class='#{this.class.parent.name.downcase}-state-#{this.to_s.downcase} state-#{this.to_s.downcase}'>
+    <span class='#{this.class.parent.name.downcase}-states #{this.class.parent.name.downcase}-state-#{this.to_s.downcase} state-#{this.to_s.downcase}'>
         <ht key='#{this.class.parent.name.tableize}.lifecycle_states.#{this.to_s.downcase}'><%= this.to_s %></ht>
     </span>
 </def>

--- a/hobo/taglibs/rapid_core.dryml
+++ b/hobo/taglibs/rapid_core.dryml
@@ -495,7 +495,11 @@ Assuming the context is a blog post...
 <def tag="view" for="ActiveRecord::Base"><a merge-attrs/></def>
 
 <!-- Renders `this.to_s` with localization support -->
-<def tag="view" for="HoboFields::LifecycleState"><ht key='#{this.class.parent.name.tableize}.lifecycle_states.#{this.to_s.downcase}'><%= this.to_s %></ht></def>
+<def tag="view" for="HoboFields::LifecycleState">
+    <span class='#{this.class.parent.name.downcase}-state-#{this.to_s.downcase} state-#{this.to_s.downcase}'>
+        <ht key='#{this.class.parent.name.tableize}.lifecycle_states.#{this.to_s.downcase}'><%= this.to_s %></ht>
+    </span>
+</def>
 
 
 <!--

--- a/hobo/taglibs/rapid_core.dryml
+++ b/hobo/taglibs/rapid_core.dryml
@@ -489,7 +489,7 @@ Assuming the context is a blog post...
 %></def>
 
 <!-- Renders 'Yes' for true and 'No' for false -->
-<def tag="view" for="boolean"><%= this ? I18n.t('hobo.boolean_yes', :default => 'Yes') : I18n.t('hobo.boolean_no', :default => 'no') %></def>
+<def tag="view" for="boolean"><%= this ? ht('hobo.boolean_yes', {:default => 'Yes'}) : ht('hobo.boolean_no', {:default => 'No'}) %></def>
 
 <!-- Renders a link (`<a>`) to `this` -->
 <def tag="view" for="ActiveRecord::Base"><a merge-attrs/></def>

--- a/hobo/taglibs/rapid_forms.dryml
+++ b/hobo/taglibs/rapid_forms.dryml
@@ -780,10 +780,10 @@ If you wish to set `min-chars` to 0, you will require this [patch to controls.js
   -->
 <def tag="error-messages">
   <section class="error-messages" merge-attrs if="&this.errors.length > 0">
-    <h2 param="heading">To proceed please correct the following:</h2>
+      <h2 param="heading"><ht key="hobo.messages.error_correct_following">To proceed please correct the following:</ht></h2>
     <ul param>
       <% this.errors.each do |attr, message|; next if message == "..." -%>
-        <li param><%= this.class.human_attribute_name(attr) unless attr.to_s == 'base' %> <%= message %></li>
+        <li param><%= this.class.view_hints.field_name(attr) unless attr.to_s == 'base' %> <%= message %></li>
       <% end -%>
     </ul>
   </section>

--- a/hobo/taglibs/rapid_forms.dryml
+++ b/hobo/taglibs/rapid_forms.dryml
@@ -574,7 +574,7 @@ All the standard ajax attributes *except the callbacks* are supported (see the m
                                   else
                                     { :type => "button" }
                                   end)
-    label ||= ht("hobo.actions.remove", :default=>"Remove") 
+    label ||= ht("#{this.class.name.tableize}.actions.remove", :default=>"Remove") 
     confirm = ht("hobo.messages.confirm", :default=>"Are you sure?") if confirm.nil?
     
     add_classes!(attributes,
@@ -801,7 +801,7 @@ To use this tag, the model of the items the user is chosing *must* have unique n
   name ||= param_name_for_this
                 
   values = this
-  remove_label ||= ht("hobo.actions.remove", :default=>'Remove')
+  remove_label ||= ht("#{this.name.tableize}.actions.remove", :default=>'Remove')
   -%>
   <div class="input select-many" merge-attrs>
     <div style="display:none" class="item-proto">

--- a/hobo/taglibs/rapid_forms.dryml
+++ b/hobo/taglibs/rapid_forms.dryml
@@ -622,7 +622,7 @@ All of the standard ajax attributes are supported (see the main taglib documenti
   new = class_or_assoc.new(fields)
   new.set_creator(current_user)
   if can_create?(new)
-    label ||= ht("#{new.class.name.pluralize.underscore}.actions.new", :default=>"New #{new.class.name.titleize}")  
+    label ||= ht("#{new.class.name.tableize}.actions.new", :default=>"New #{new.class.name.titleize}")  
     ajax_attributes = { :message => message }
     class_name = new.class.name.underscore
     ajax_attributes[:params] = { class_name => fields } unless fields.empty?
@@ -653,7 +653,7 @@ For situations where there are too many target records to practically include in
 <def tag="select-one" attrs="include-none, blank-message, options, sort, limit, text-method"><%
   raise HoboError.new("Not allowed to edit #{this_field}") if !attributes[:disabled] && !can_edit? 
 
-  blank_message ||= ht("#{this_type.name.underscore}.message.no", :default=>"(No #{this_type.view_hints.model_name})")
+  blank_message ||= ht("#{this_type.name.tableize}.message.none", :default=>"(No #{this_type.view_hints.model_name})")
   limit ||= 100
    
   options ||= begin
@@ -796,7 +796,7 @@ An input for `has_many :through` associations that lets the user chose the items
 To use this tag, the model of the items the user is chosing *must* have unique names, and the 
 -->
 <def tag="select-many" attrs="options, targets, remove-label, prompt, disabled, name"><%
-  prompt ||= "Add #{this_field.titleize.singularize}"
+  prompt ||= ht("#{this.name.tableize}.message.none", :default=>"Add #{this.view_hints.model_name}")
   options ||= this_field_reflection.klass.all(:conditions =>this.conditions).select {|x| can_view?(x)}
   name ||= param_name_for_this
                 

--- a/hobo/taglibs/rapid_plus.dryml
+++ b/hobo/taglibs/rapid_plus.dryml
@@ -172,7 +172,7 @@ See [Filtering stories by status](/tutorials/agility#filtering_stories_by_status
   <% no_filter ||= "All" %>
   <form action="&request.request_uri" method="get" class="filter-menu" merge-attrs="id">
     <div>
-      <% selected = options.detect {|o| o.to_s==params[param_name.gsub('-', '_')] } %>
+      <% selected = options.detect {|o| o.is_a?(Array) ? o[1].to_s==params[param_name.gsub('-', '_')] : o.to_s==params[param_name.gsub('-', '_')] } %>
       <select-menu name="&param_name" options="&options" selected="&selected"
                    first-option="&no_filter" merge-params/>
     </div>

--- a/hobo/taglibs/rapid_user_pages.dryml
+++ b/hobo/taglibs/rapid_user_pages.dryml
@@ -165,8 +165,8 @@ if a given email is associated with an account or not. -->
         <error-messages param/>
         <form class="change-password" param>
           <field-list fields="email_address, current_password, password, password_confirmation" param>
-            <password-label:>New Password</password-label:>
-            <password-confirmation-label:>Confirm New Password</password-confirmation-label:>
+              <password-label:><ht key="users.new_password">"New Password</ht></password-label:>
+              <password-confirmation-label:><ht key="users.confirm_new_password">Confirm New Password</ht></password-confirmation-label:>
           </field-list>
 
           <div class="actions" param="actions">


### PR DESCRIPTION
#### Last 2 commits:

tacid@55bee3e86029cd1985ab2a48df84b8db672e2e51 : order_by now can be used with has_many_assoc.count. For example in controller U can use now

```
def index 
    hobo_index Category.apply_scope(:order_by => parse_sort_param("name", "stories.count"))
end 
```

when the "stories" is has_many association in Category model

tacid@c4e768d51f961282faddfbbb92aa02518f8648b7 : filter-menu tag incorectly sets "selected=" when options is array of [opt_name, opt_value], like
options = [["Option1", 1], ["Option2", 2], ["Option3", 3], ["Option4", 4]] 
while select-menu tag works with such an options array
