### PR TITLE
Fix for Chronic.parse options

### DIFF
--- a/hobo_support/lib/hobo_support/fixes/chronic.rb
+++ b/hobo_support/lib/hobo_support/fixes/chronic.rb
@@ -5,7 +5,7 @@ begin
   module Chronic
 
     class << self
-      def parse_with_hobo_fix(s)
+      def parse_with_hobo_fix(s, *options)
         if s =~ /^\s*\d+\s*(st|nd|rd|th)\s+[a-zA-Z]+(\s+\d+)?\s*$/
           s = s.sub(/\s*\d+(st|nd|rd|th)/) {|s| s[0..-3]}
         end
@@ -13,7 +13,7 @@ begin
         # Chronic can't parse '1/1/2008 1:00' or '1/1/2008 1:00 PM',
         # so convert them to '1/1/2008 @ 1:00' and '1/1/2008 @ 1:00 PM'
         s = s.sub(/^\s*(\d+\/\d+\/\d+)\s+(\d+:\d+.*)/, '\1 @ \2')
-        parse_without_hobo_fix(s)
+        parse_without_hobo_fix(s, *options)
       end
       alias_method_chain :parse, :hobo_fix
     end

--- a/hobo_support/test/hobosupport/chronic.rdoctest
+++ b/hobo_support/test/hobosupport/chronic.rdoctest
@@ -1,0 +1,18 @@
+# HoboSupport - Chronic extensions
+
+    doctest_require: '../../lib/hobo_support'
+{.hidden}
+
+## `Chronic.parse`
+
+Chronic.parse can't parse 'M/D/Y H:S', so convert it to 'M/D/Y @ H:S'.
+
+    >> Chronic.parse('1/1/2008 1:00') == Chronic.parse('1/1/2008 @ 1:00')
+
+    => true
+
+Chronic.parse takes additional options (see Chronic.parse).
+
+    >> Chronic.parse('today', :guess => false).instance_of? Chronic::Span
+
+    => true


### PR DESCRIPTION
Chronic.parse takes an options parameter, but Hobo's fixed version didn't allow options. With this commit, it does (and will also support other parameters, should Chronic someday add them).

This is my first attempt at a rubydoctest, so you may want to clean that part up.
