### PR TITLE
#921: Migration generator fails on habtm relationships

### DIFF
--- a/hobo_fields/lib/generators/hobo/migration/migrator.rb
+++ b/hobo_fields/lib/generators/hobo/migration/migrator.rb
@@ -18,6 +18,10 @@ module Generators
           self.join_table
         end
 
+        def table_exists?
+          ActiveRecord::Migration.table_exists? table_name
+        end
+
         def field_specs
           i = 0
           foreign_keys.inject({}) do |h, v|


### PR DESCRIPTION
https://hobo.lighthouseapp.com/projects/8324-hobo/tickets/921-migration-generator-fails-on-habtm-relationships

The patch fixes the above bug. Here's the description from Lighthouse:

The migration generator doesn't work for habtm relationships, because it tries to call #table_exists? on HabtmModelShim. That method does not exist, so the generator fails.
