### PR TITLE
Adds helper scope to User

### DIFF
--- a/hobo/lib/hobo/model/user.rb
+++ b/hobo/lib/hobo/model/user.rb
@@ -49,7 +49,8 @@ module Hobo
 
           attr_protected *AUTHENTICATION_FIELDS
 
-
+          # Scope to retrieve all administrators
+          scope :administrators, :conditions => {:administrator => true}
         end
       end
 


### PR DESCRIPTION
This commit adds a simple scope to retrieve all admins.

I find it useful when apps need to send e-mails to all admins. I'm making this pull request because I use this scope in almost every app, so it might be useful to provide it out of the box.

Thanks,
  Tiago Franco
