### PR TITLE
Allow :null=>false to be default for text, string and boolean fields

### DIFF
--- a/hobo/lib/hobo/controller/user.rb
+++ b/hobo/lib/hobo/controller/user.rb
@@ -87,6 +87,9 @@ module Hobo
       do_creator_action(:signup) do
         if valid?
           flash[:notice] = ht(:"#{model.to_s.underscore}.messages.signup.success", :default=>["Thanks for signing up!"])
+        else
+          this.password = HoboFields::Types::PasswordString.new
+          this.password_confirmation = HoboFields::Types::PasswordString.new
         end
         response_block(&b) or if valid?
                                 self.current_user = this if this.account_active?

--- a/hobo/lib/hobo/engine.rb
+++ b/hobo/lib/hobo/engine.rb
@@ -16,6 +16,7 @@ module Hobo
       h.read_only_file_system = !!ENV['HEROKU_TYPE']
       h.show_translation_keys = false
       h.dryml_only_templates = false
+      h.null_false_by_default = false
     end
 
     ActiveSupport.on_load(:action_controller) do

--- a/hobo/lib/hobo/model.rb
+++ b/hobo/lib/hobo/model.rb
@@ -347,8 +347,8 @@ module Hobo
         view_hints.inline_booleans *args
       end
 
-      def table_exists?
-        @table_exists_cache = super if @table_exists_cache.nil?
+      def table_exists?(refresh = false)
+        @table_exists_cache = super() if (refresh or @table_exists_cache.nil?)
         @table_exists_cache
       end
 

--- a/hobo_fields/lib/hobo_fields/model/field_spec.rb
+++ b/hobo_fields/lib/hobo_fields/model/field_spec.rb
@@ -55,7 +55,12 @@ module HoboFields
       end
 
       def null
-        :null.in?(options) ? options[:null] : true
+        if Rails.application.config.hobo.null_false_by_default
+          return options[:null] if options.include? :null
+          return (not [:text, :string, :boolean].include? sql_type)
+        else
+          :null.in?(options) ? options[:null] : true
+        end
       end
 
       def default


### PR DESCRIPTION
In my apps I set 

```
:null => false
```

on most text, string an bool fields. So I think it may be a good idea to allow users to set

```
:null => false
```

by default on those field types.
