### PR TITLE
XSS in HoboFields::EmailAddress

### DIFF
--- a/hobofields/lib/hobo_fields/email_address.rb
+++ b/hobofields/lib/hobo_fields/email_address.rb
@@ -13,7 +13,7 @@ module HoboFields
     end
 
     def to_html(xmldoctype = true)
-      self.sub('@', " at ").gsub('.', ' dot ')
+      ERB::Util.h(self.sub('@', " at ").gsub('.', ' dot '))
     end
 
     HoboFields.register_type(:email_address, self)


### PR DESCRIPTION
Time to get 1.3 out and recommend people stop using 1.0? I doubt this is the only place this happens. Rails 3 with its html_safe strings is probably much better. If we don't get that out then I think we should do 1.0.4.
