### PR TITLE
Add a 20 records limit to the live-search

### DIFF
--- a/hobo/lib/hobo.rb
+++ b/hobo/lib/hobo.rb
@@ -49,7 +49,7 @@ module Hobo
         end
         conditions = conditions.join(" and ")
 
-        results = search_target.where(conditions, *parameters)
+        results = search_target.where(conditions, *parameters).limit(20)
         [search_target.name, results] unless results.empty?
       end
     end


### PR DESCRIPTION
Right now live-search does not have any limit. This can become a problem very easily, creating long queries and enormous scrolls.

I just added a fixed limit to the find_by_search function. 

In the future this could be improved with more config options, or even pagination.
