### PR TITLE
Problems with capybara sessions.

### DIFF
--- a/hobo/app/controllers/dev_controller.rb
+++ b/hobo/app/controllers/dev_controller.rb
@@ -10,8 +10,8 @@ class DevController < ActionController::Base
                           model.where(model.login_attribute => params[:login]).first
                         else
                           model.find(params[:id])
-                        end
-    redirect_to(request.env["HTTP_REFERER"] ? :back : home_page)
+                        end      
+    redirect_to(request.env["HTTP_REFERER"] ? :back : (home_page.blank? ? "/" : home_page))
   end
 
   private


### PR DESCRIPTION
Hi,

I found a problem when using hobo with capybara. in dev_controller.rb. When redirecting to "" (home_page has this value by default) capybara 'forgets' the session. Do you know if redirect to "" is really allowed?  Maybe the home_page should have a real value instead of "". Think this would solve the problem also.

> Capybara does not remember session when redirecting to "". Use "/" instead.
