### PR TITLE
Fixes core tags being escaped by Rails 3+

### DIFF
--- a/dryml/README
+++ b/dryml/README
@@ -9,24 +9,28 @@ not optimized for that and you may end up with extra carriage returns.
 DRYML was created for the Hobo project, but this is an extraction from
 that project and can be used separately.
 
-# How to use with Rails but without Hobo
+# How to use with Rails 3 but without Hobo
 
-- install both HoboSupport and Dryml as a plugin or gem
+- Declare the Dryml gem in your `Gemfile` 
+    
+    gem 'dryml'
 
-- create an `application.dryml`
+- Then update your bundle
+
+    $ bundle install
+
+- Create an `application.dryml`
 
     $ mkdir app/views/taglibs
     $ touch app/views/taglibs/application.dryml
 
-- create `config/initializers/dryml.rb`
+Now you can use templates that end in ".dryml" or ".html.dryml".  Controller 
+layouts will still be rendered and will enclose your templates, but you can 
+disable them if you wish in your ApplicationController:
 
-    require 'dryml'
-    require 'dryml/template'
-    require 'dryml/dryml_generator'
-    Dryml.enable
-
-Now you can use templates that end in ".dryml".  Such templates will
-ignore layouts.
+    class ApplicationController < ActionController::Base
+      layout nil
+    end
 
 # How to use outside of Rails
 

--- a/dryml/taglibs/core.dryml
+++ b/dryml/taglibs/core.dryml
@@ -115,32 +115,32 @@ collection is considered blank)
 
 
 <!-- nodoc.  Define core HTML tags defined in Rapid so that DRYML can be used without Rapid. -->
-<def tag="html"><%=raw "<html#{tag_options(attributes, true)}>" -%><do param="default"/><%= "</html>" -%></def>
+<def tag="html"><%=raw "<html#{tag_options(attributes, true)}>" -%><do param="default"/><%= raw "</html>" -%></def>
 
 <!-- nodoc.  Define core HTML tags defined in Rapid so that DRYML can be used without Rapid. -->
-<def tag="table"><%=raw "<table#{tag_options(attributes, true)}>" -%><do param="default"/><%= "</table>" -%></def>
+<def tag="table"><%=raw "<table#{tag_options(attributes, true)}>" -%><do param="default"/><%= raw "</table>" -%></def>
 
 <!-- nodoc.  Define core HTML tags defined in Rapid so that DRYML can be used without Rapid. -->
-<def tag="a"><%=raw "<a#{tag_options(attributes, true)}>" -%><do param="default"/><%= "</a>" -%></def>
+<def tag="a"><%=raw "<a#{tag_options(attributes, true)}>" -%><do param="default"/><%= raw "</a>" -%></def>
 
 <!-- nodoc.  Define core HTML tags defined in Rapid so that DRYML can be used without Rapid. -->
-<def tag="section"><%=raw "<section#{tag_options(attributes, true)}>" -%><do param="default"/><%= "</section>" -%></def>
+<def tag="section"><%=raw "<section#{tag_options(attributes, true)}>" -%><do param="default"/><%= raw "</section>" -%></def>
 
 <!-- nodoc.  Define core HTML tags defined in Rapid so that DRYML can be used without Rapid. -->
-<def tag="header"><%=raw "<header#{tag_options(attributes, true)}>" -%><do param="default"/><%= "</header>" -%></def>
+<def tag="header"><%=raw "<header#{tag_options(attributes, true)}>" -%><do param="default"/><%= raw "</header>" -%></def>
 
 <!-- nodoc.  Define core HTML tags defined in Rapid so that DRYML can be used without Rapid. -->
-<def tag="footer"><%=raw "<footer#{tag_options(attributes, true)}>" -%><do param="default"/><%= "</footer>" -%></def>
+<def tag="footer"><%=raw "<footer#{tag_options(attributes, true)}>" -%><do param="default"/><%= raw "</footer>" -%></def>
 
 <!-- nodoc.  Define core HTML tags defined in Rapid so that DRYML can be used without Rapid. -->
-<def tag="form"><%=raw "<form#{tag_options(attributes, true)}>" -%><do param="default"/><%= "</form>" -%></def>
+<def tag="form"><%=raw "<form#{tag_options(attributes, true)}>" -%><do param="default"/><%= raw "</form>" -%></def>
 
 <!-- nodoc.  Define core HTML tags defined in Rapid so that DRYML can be used without Rapid. -->
-<def tag="submit"><%=raw "<submit#{tag_options(attributes, true)}>" -%><do param="default"/><%= "</submit>" -%></def>
+<def tag="submit"><%=raw "<submit#{tag_options(attributes, true)}>" -%><do param="default"/><%= raw "</submit>" -%></def>
 
 <!-- nodoc.  Define core HTML tags defined in Rapid so that DRYML can be used without Rapid. -->
-<def tag="input"><%=raw "<input#{tag_options(attributes, true)}>" -%><do param="default"/><%= "</input>" -%></def>
+<def tag="input"><%=raw "<input#{tag_options(attributes, true)}>" -%><do param="default"/><%= raw "</input>" -%></def>
 
 <!-- nodoc.  Define core HTML tags defined in Rapid so that DRYML can be used without Rapid. -->
-<def tag="link"><%=raw "<link#{tag_options(attributes, true)}>" -%><do param="default"/><%= "</link>" -%></def>
+<def tag="link"><%=raw "<link#{tag_options(attributes, true)}>" -%><do param="default"/><%= raw "</link>" -%></def>
 


### PR DESCRIPTION
The ending of some core tags (ex.: html, form, etc) were not being output with raw, therefore Rails was escaping them. This should fix it, plus it updates the README to explain how to use Dryml in Rails 3.

**Note/Pledge to Hobo developers**: I am not a Hobo user (my projects need a fair bit of customization and I tend to go with "Rails raw" to start from ground up), but I have been watching you guys work for a long time and willing to be able to use Dryml on its own for a long time. I think Rails views (sum of ERB + helpers + partials) are a crappy mess, you end up with lots of unreadable code that is really hard to reuse and maintain. Dryml is the best and only solution I have seen for this sulkiness so far, and it's been like that for years now: nothing else comes along, and Dryml remains a promise just a few people and the Hobo niche use. Yet people are jumping on the HAML and Formtastic bandwagon, when they are nothing but "gimmicks" that don't solve the architectural problem.

Besides thanking for the nice work, I want to make a pledge: invest in polishing and "marketing" Dryml as the solution it is for Rails views, try to bring users and developers to use it "standalone". You should try talking to Rails core guys. I think it should be bundled in future versions of Rails, just like sass and coffeescript were, being much less needed. You could create a  "Rapid Basic" set of Dryml tags to be included in the gem that work in standalone Rails and basically replace (or wrap) Rails helpers. 

I am willing to go "early adopter" on standalone Dryml with my production projects, but to be honest it is a great leap in the dark: I am really worried about getting stuck in showstopper bugs or huge performance bottlenecks and being on my own. My firm is a small and underfunded startup and needs to focus on its bottom line, the sane decision would be to stay in "vanilla Rails", but I am so disgusted, after all this years, of having crappy code in my views.
