### PR TITLE
Fix for ticket 1000: support changing locale for EnumString translations

### DIFF
--- a/hobo/lib/hobo/rapid/taglibs/rapid_core.dryml
+++ b/hobo/lib/hobo/rapid/taglibs/rapid_core.dryml
@@ -515,6 +515,22 @@ Assuming the context is a blog post...
   end
 %></def>
 
+<!-- This tag add internationalization support to EnumString fields -->
+<def tag="view" for="HoboFields::Types::EnumString">
+  <%=
+  content = this
+  model = this_parent.class
+  for column in model.content_columns.*.name
+    if model.attr_type(column) == this_type
+      content = I18n.t(
+        "activerecord.attributes.#{model.to_s.downcase}/#{column}s.#{content}",
+        :default => content.titleize)
+    end
+  end
+  content
+  %>
+</def>
+
 <!-- Renders 'Yes' for true and 'No' for false -->
 <def tag="view" for="boolean"><%= this ? t('hobo.boolean_yes', :default => 'Yes') : t('hobo.boolean_no', :default => 'No') %></def>
 

--- a/hobo/lib/hobo/rapid/taglibs/rapid_core.dryml
+++ b/hobo/lib/hobo/rapid/taglibs/rapid_core.dryml
@@ -518,16 +518,10 @@ Assuming the context is a blog post...
 <!-- This tag add internationalization support to EnumString fields -->
 <def tag="view" for="HoboFields::Types::EnumString">
   <%=
-  content = this
   model = this_parent.class
-  for column in model.content_columns.*.name
-    if model.attr_type(column) == this_type
-      content = I18n.t(
-        "activerecord.attributes.#{model.to_s.downcase}/#{column}s.#{content}",
-        :default => content.titleize)
-    end
-  end
-  content
+  I18n.t(
+    "activerecord.attributes.#{model.to_s.downcase}/#{this_field}s.#{this}",
+    :default => this.titleize)
   %>
 </def>
 

--- a/hobo/lib/hobo/rapid/taglibs/rapid_editing.dryml
+++ b/hobo/lib/hobo/rapid/taglibs/rapid_editing.dryml
@@ -73,7 +73,18 @@ This tag does not sanitize HTML; this is provided by HtmlString before saving to
 
 <!-- Provides an editor that uses a `<select>` menu. Uses the `<string-select-editor>` tag. -->
 <def tag="editor" for="HoboFields::Types::EnumString">
- <string-select-editor values="&this_type.values" merge/>
+ <%
+  model = this_parent.class
+  # I18N: First we need to find the column name searching in the content_columns
+  for column in model.content_columns.*.name
+    if model.attr_type(column) == this_type
+      options = Hash[this_type.values.map {|v| [v.to_sym, 
+        I18n.t("activerecord.attributes.#{model.to_s.downcase}/#{column}s.#{v}", 
+          :default => v.titleize)]}]
+    end
+  end
+ %>
+ <string-select-editor values="&this_type.values" labels="&options" merge/>
 </def>
 
 <!-- Provides a `<select>` menu with an ajax callback to update a `belongs_to` relationship when changed.

--- a/hobo/lib/hobo/rapid/taglibs/rapid_editing.dryml
+++ b/hobo/lib/hobo/rapid/taglibs/rapid_editing.dryml
@@ -75,14 +75,11 @@ This tag does not sanitize HTML; this is provided by HtmlString before saving to
 <def tag="editor" for="HoboFields::Types::EnumString">
  <%
   model = this_parent.class
-  # I18N: First we need to find the column name searching in the content_columns
-  for column in model.content_columns.*.name
-    if model.attr_type(column) == this_type
-      options = Hash[this_type.values.map {|v| [v.to_sym, 
-        I18n.t("activerecord.attributes.#{model.to_s.downcase}/#{column}s.#{v}", 
-          :default => v.titleize)]}]
-    end
-  end
+  options = Hash[this_type.values.map {|v| [
+    v.to_sym, 
+    I18n.t("activerecord.attributes.#{model.to_s.downcase}/#{this_field}s.#{v}", 
+      :default => v.titleize)
+  ]}]
  %>
  <string-select-editor values="&this_type.values" labels="&options" merge/>
 </def>

--- a/hobo/lib/hobo/rapid/taglibs/rapid_forms.dryml
+++ b/hobo/lib/hobo/rapid/taglibs/rapid_forms.dryml
@@ -476,10 +476,12 @@ The menus default to the current time if the current value is nil.
 <def tag="input" for="HoboFields::Types::EnumString" attrs="labels, titleize, first-option, first-value"><%
   labels ||= {}
   labels = HashWithIndifferentAccess.new(labels)
-  titleize = true if titleize.nil?
-  options = this_type.values.map {|v| 
+  titleize = true if titleize.nil? && labels.empty?
+  options = this_type.values.map {|v|
+    default = labels[v] || v
+    default = default.titleize if titleize
     [I18n.t("activerecord.attributes.#{this_parent.class.to_s.downcase}/#{this_field}s.#{v}",
-      :default => titleize ? v.titleize : v), 
+      :default => default),
     v]
   }
   %>
@@ -488,7 +490,6 @@ The menus default to the current time if the current value is nil.
     <%= options_for_select(options, this) %>
   </select>
 </def>
-
 
 <!-- Provides either an ajax or non-ajax button to invoke a "remote method" or "web method" declared in the controller.
 Web Methods provide support for the RPC model of client-server interaction, in contrast to the REST model. The

--- a/hobo/lib/hobo/rapid/taglibs/rapid_forms.dryml
+++ b/hobo/lib/hobo/rapid/taglibs/rapid_forms.dryml
@@ -477,7 +477,17 @@ The menus default to the current time if the current value is nil.
   labels ||= {}
   labels = HashWithIndifferentAccess.new(labels)
   titleize = true if titleize.nil?
-  options = this_type.values.map {|v| [labels.fetch(v, titleize ? this_type.translated_values[v].titleize : this_type.translated_values[v]), v] }
+  model = this_parent.class
+  # I18N: First we need to find the column name searching in the content_columns
+  for column in model.content_columns.*.name
+    if model.attr_type(column) == this_type
+      options = this_type.values.map {|v| 
+        [
+          I18n.t("activerecord.attributes.#{model.to_s.downcase}/#{column}s.#{v}",
+          :default => titleize ? v.titleize : v), 
+        v]}
+    end
+  end
   %>
   <select name="#{param_name_for_this}" merge-attrs>
     <option value="#{first_value}" unless="&first_option.nil?"><first-option/></option>

--- a/hobo/lib/hobo/rapid/taglibs/rapid_forms.dryml
+++ b/hobo/lib/hobo/rapid/taglibs/rapid_forms.dryml
@@ -477,17 +477,11 @@ The menus default to the current time if the current value is nil.
   labels ||= {}
   labels = HashWithIndifferentAccess.new(labels)
   titleize = true if titleize.nil?
-  model = this_parent.class
-  # I18N: First we need to find the column name searching in the content_columns
-  for column in model.content_columns.*.name
-    if model.attr_type(column) == this_type
-      options = this_type.values.map {|v| 
-        [
-          I18n.t("activerecord.attributes.#{model.to_s.downcase}/#{column}s.#{v}",
-          :default => titleize ? v.titleize : v), 
-        v]}
-    end
-  end
+  options = this_type.values.map {|v| 
+    [I18n.t("activerecord.attributes.#{this_parent.class.to_s.downcase}/#{this_field}s.#{v}",
+      :default => titleize ? v.titleize : v), 
+    v]
+  }
   %>
   <select name="#{param_name_for_this}" merge-attrs>
     <option value="#{first_value}" unless="&first_option.nil?"><first-option/></option>


### PR DESCRIPTION
Hi,

I wrote a fix for https://hobo.lighthouseapp.com/projects/8324/tickets/1000-i18n-support-switching-locales-with-enum_string. Basically I modify the view, input and editor for EnumString fields so they support i18n. I also believe we could get rid of some enumstring i18n code in hobo_fields, if you want I can take a look at that too.

I'm not sure if this is the right branch to make a pull request. Maybe you prefer me to test this against Hobo 1.4 and pull the request there. Just tell me :).
