### PR TITLE
Fix for Ticket 1003 - polymorphic-associations-broken / just 2 lines !!

### DIFF
--- a/hobo/lib/hobo/model.rb
+++ b/hobo/lib/hobo/model.rb
@@ -167,7 +167,8 @@ module Hobo
           #       (ie X belongs_to Y (polymorphic), Z is a subclass of Y; @x.y_is?(some_z) will never pass)
           class_eval %{
             def #{name}_is?(target)
-              target.class.name == self.#{refl.options[:foreign_type]} && target.#{id_method} == self.#{refl.foreign_key}
+            
+              target.class.name == self.#{refl.foreign_type} && target.#{id_method} == self.#{refl.foreign_key}
             end
             def #{name}_changed?
               #{refl.foreign_key}_changed? || #{refl.options[:foreign_type]}_changed?

--- a/hobo/lib/hobo/model.rb
+++ b/hobo/lib/hobo/model.rb
@@ -167,11 +167,10 @@ module Hobo
           #       (ie X belongs_to Y (polymorphic), Z is a subclass of Y; @x.y_is?(some_z) will never pass)
           class_eval %{
             def #{name}_is?(target)
-            
               target.class.name == self.#{refl.foreign_type} && target.#{id_method} == self.#{refl.foreign_key}
             end
             def #{name}_changed?
-              #{refl.foreign_key}_changed? || #{refl.options[:foreign_type]}_changed?
+              #{refl.foreign_key}_changed? || #{refl.foreign_type}_changed?
             end
           }
         else


### PR DESCRIPTION
Lighthouse-Ticket-Link:
https://hobo.lighthouseapp.com/projects/8324/tickets/1003-polymorphic-associations-broken-in-hobo-140pre5

Shows the problem:
https://gist.github.com/2954021

refl.options[:foreign_type] => not accessible
refl.foreign_key => accessible

Sorry for the two commits.
