### PR TITLE
[#1007] target.new and target.build adds new empty element in collection...

### DIFF
--- a/hobo_rapid/taglibs/html/a.dryml
+++ b/hobo_rapid/taglibs/html/a.dryml
@@ -114,7 +114,7 @@ The standard AJAX attributes are supported.
       nil_view
     elsif action == "new"
       # Link to a new object form
-      new_record = target.respond_to?(:build) ? target.build : target.new
+      new_record = (target.class==Array) ? target.member_class.new : target.new
       new_record.set_creator(current_user)
       href = object_url(target, "new", params._?.merge(:subsite => subsite))
 


### PR DESCRIPTION
Hi,
As said in ticket 1007, this issue is not solved by using build. An empty element is still added to the collection when using a <a> tag.
