### PR TITLE
Remove some commas in JS files so IE7 does not complain

### DIFF
--- a/hobo_jquery/vendor/assets/javascripts/hobo-jquery/hjq-form.js
+++ b/hobo_jquery/vendor/assets/javascripts/hobo-jquery/hjq-form.js
@@ -14,7 +14,7 @@
             var annotations = form.data('rapid').form;
 
             var options = {type: form[0].method,
-                           attrs: annotations.ajax_attrs,
+                           attrs: annotations.ajax_attrs
                           };
 
             if(form.attr('enctype') == 'multipart/form-data') {

--- a/hobo_jquery/vendor/assets/javascripts/hobo-jquery/hjq-spinner.js
+++ b/hobo_jquery/vendor/assets/javascripts/hobo-jquery/hjq-spinner.js
@@ -56,7 +56,7 @@
             if(!clone) return this;
             clone.remove();
             return this;
-        },
+        }
     };
 
     var defaultOptions = function() {

--- a/hobo_jquery_ui/vendor/assets/javascripts/combobox.js
+++ b/hobo_jquery_ui/vendor/assets/javascripts/combobox.js
@@ -19,7 +19,7 @@
             clearButton: true,
             adjustWidth: true,
             uiStyle: false,
-            selected: null,
+            selected: null
         },
 	_create: function() {
 	    var self = this,


### PR DESCRIPTION
This is related to this issue: https://github.com/bryanlarsen/hobo-jquery/issues/12

I found a few extra commas that were making IE7 complain. There's a funny article talking about it: http://www.enterprisedojo.com/2010/12/19/beware-the-trailing-comma-of-death/
