### PR TITLE
Change _update to hjq.ajax.update as default Ajax update function

### DIFF
--- a/hobo/lib/hobo/controller.rb
+++ b/hobo/lib/hobo/controller.rb
@@ -83,7 +83,7 @@ module Hobo
 
       page = options[:preamble] || "var _update = typeof Hobo == 'undefined' ? Element.update : Hobo.updateElement;\n"
       for spec in render_specs
-        function = spec[:function] || "_update"
+        function = spec[:function] || "hjq.ajax.update"
         dom_id = spec[:id]
 
         if spec[:part_context]


### PR DESCRIPTION
I've been working a bit with Ajax in a Hobo 1.4 and I realised that the __update_ function was failing, and that replacing it with _hjq.ajax.update_ (as used in the global search) it works. I'm not sure if _update has been deprecated or I'm just doing something else wrong :P.
