### PR TITLE
Fix problem with long part context codes.

### DIFF
--- a/dryml/lib/dryml/part_context.rb
+++ b/dryml/lib/dryml/part_context.rb
@@ -56,7 +56,9 @@
       def marshal(session)
         context = [@part_name, @this_id, @locals]
         context << form_field_path if form_field_path
-        data = Base64.encode64(Marshal.dump(context)).strip
+        # http://stackoverflow.com/questions/2620975/strange-n-in-base64-encoded-string-in-ruby
+        # data = Base64.encode64(Marshal.dump(context)).strip
+        data = Base64.strict_encode64(Marshal.dump(context)).strip
         digest = generate_digest(data, session)
         "#{data}--#{digest}"
       end
@@ -65,7 +67,6 @@
       # Unmarshal part context to a hash and verify its integrity.
       def unmarshal(client_store, page_this, session)
         data, digest = CGI.unescape(client_store).strip.split('--')
-
         raise TamperedWithPartContext unless digest == generate_digest(data, session)
 
         context = Marshal.load(Base64.decode64(data))


### PR DESCRIPTION
We suffered a problem while using partials: if "data" was bigger than 60 characters, a newline character was being added to the part ('\n'). When parsing this with jquery, it was removing the new line, and so we were getting a TamperedWithPartContext error. 

We found out that replacing encode64 with strict_encode64 solved our problem.

See http://stackoverflow.com/questions/2620975/strange-n-in-base64-encoded-string-in-ruby
