### PR TITLE
Update hobo/lib/hobo/extensions/active_record/associations/reflection.rb

### DIFF
--- a/hobo/lib/hobo/extensions/active_record/associations/reflection.rb
+++ b/hobo/lib/hobo/extensions/active_record/associations/reflection.rb
@@ -9,7 +9,7 @@ module ActiveRecord
           begin
             klass_without_create_polymorphic_class
           rescue NameError => e
-            Object.class_eval "class #{e.missing_name} < ActiveRecord::Base; set_table_name '#{active_record.name.tableize}'; def self.hobo_shim?; true; end; end"
+            Object.class_eval "class #{e.missing_name} < ActiveRecord::Base; self.table_name = '#{active_record.name.tableize}'; def self.hobo_shim?; true; end; end"
             e.missing_name.constantize
           end
         else


### PR DESCRIPTION
DEPRECATION WARNING: Calling set_table_name is deprecated. Please use `self.table_name = 'the_name'` instead. (called from class:MyModel at (eval):1)
